### PR TITLE
Reworded end of use login sequence to reference w3c spec

### DIFF
--- a/draft-ietf-rtcweb-security-arch.xml
+++ b/draft-ietf-rtcweb-security-arch.xml
@@ -1721,9 +1721,8 @@ IdPProxy -> PeerConnection:
                 in order to trigger the required user interactions.  Once any user
                 interactions are complete, the IFRAME MUST send a <xref
                 target="WebMessaging">postMessage</xref> to its containing window
-                indicating completion.  Any message is sufficient for this
-                purpose, the <spanx style="verb">source</spanx> parameter
-                identifies the originating IFRAME.
+                indicating completion, as described in section 8.2.1 of 
+                <xref target="webrtc-api"/>.
               </t>
               <t>
                 In all other respects, "LOGINNEEDED" can be treated as an


### PR DESCRIPTION
As discussed on list: http://www.ietf.org/mail-archive/web/rtcweb/current/msg12740.html

This removes the discrepancy with the w3c spec (which says to use "LOGINDONE", not just any message) and points to the relevant part of that spec rather than duplicating it.