### PR TITLE
DTLS and cipher suite requirement update

### DIFF
--- a/draft-ietf-rtcweb-security-arch.xml
+++ b/draft-ietf-rtcweb-security-arch.xml
@@ -878,13 +878,13 @@
           All data channels MUST be secured via DTLS.
         </t>
         <t>
-          All implementations MUST implement both DTLS 1.2 and DTLS
-          1.0, with the cipher suites TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 and
-          TLS_DHE_RSA_WITH_AES_128_CBC_SHA and the DTLS-SRTP protection profile
-          SRTP_AES128_CM_HMAC_SHA1_80. Implementations SHOULD favor cipher
-          suites which support PFS over non-PFS cipher suites and GCM over
-          CBC cipher suites.
-          [[OPEN ISSUE: Should we require ECDHE? Waiting for TLS WG Consensus.]]
+          All implementations MUST implement DTLS 1.0, with the cipher suite
+          TLS_DHE_RSA_WITH_AES_128_CBC_SHA and the DTLS-SRTP protection
+          profile SRTP_AES128_CM_HMAC_SHA1_80. Implementations SHOULD implement
+          DTLS 1.2 with the TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 cipher suite.
+          Implementations SHOULD favor cipher suites which support PFS over
+          non-PFS cipher suites and GCM over CBC cipher suites.  [[OPEN ISSUE:
+          Should we require ECDSA? Waiting for consensus on IPR risks.]]
         </t>
         <!-- OPEN ISSUE: DTLS-SRTP key origin scoping? -->
         <t>
@@ -2163,7 +2163,7 @@ IdP Proxy -> PeerConnection:
           </list>
         </t>
       </section>
-      
+
     <section title="Acknowledgements">
       <t>
         Bernard Aboba, Harald Alvestrand, Richard Barnes, Dan Druta, Cullen

--- a/draft-ietf-rtcweb-security-arch.xml
+++ b/draft-ietf-rtcweb-security-arch.xml
@@ -879,9 +879,9 @@
         </t>
         <t>
           All implementations MUST implement DTLS 1.0, with the cipher suite
-          TLS_DHE_RSA_WITH_AES_128_CBC_SHA and the DTLS-SRTP protection
+          TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA and the DTLS-SRTP protection
           profile SRTP_AES128_CM_HMAC_SHA1_80. Implementations SHOULD implement
-          DTLS 1.2 with the TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 cipher suite.
+          DTLS 1.2 with the TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 cipher suite.
           Implementations SHOULD favor cipher suites which support PFS over
           non-PFS cipher suites and GCM over CBC cipher suites.  [[OPEN ISSUE:
           Should we require ECDSA? Waiting for consensus on IPR risks.]]


### PR DESCRIPTION
I think that we agreed to move to DTLS 1.0 as the MTI.

I also think that moving to ECDHE isn't at all controversial.  ECDSA might be.

I'm tempted to suggest that we say MUST on foward-secrecy capable suites, but I didn't do that.