### PR TITLE
Update to reference RFC 3986 authority

### DIFF
--- a/draft-ietf-rtcweb-security-arch.xml
+++ b/draft-ietf-rtcweb-security-arch.xml
@@ -4,6 +4,7 @@
 <!ENTITY RFC2818 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2818.xml">
 <!ENTITY RFC3261 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3261.xml">
 <!ENTITY RFC3711 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3711.xml">
+<!ENTITY RFC3711 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3986.xml">
 <!ENTITY RFC4566 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.4566.xml">
 <!ENTITY RFC4568 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.4568.xml">
 <!ENTITY RFC4648 SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.4648.xml">
@@ -1330,8 +1331,11 @@ extension-att-value = 1*(%x01-09 / %x0b-0c / %x0e-3a / %x3c-ff)
               </t>
               <t>
                 <list style="hanging">
-                  <t hangText="domain name:">
-                    The IdP's domain name
+                  <t hangText="Authority:">
+                       The <xref target="RFC3986"> authority</xref> at which the 
+                       IdP's service is hosted.  Note that this may include a non-default 
+                       port or a userinfo component, but neither will be available
+                       in a certificate verifying the site.
                   </t>
                   <t hangText="protocol:">
                     The specific IdP protocol which the IdP is using. This is a
@@ -1353,11 +1357,10 @@ extension-att-value = 1*(%x01-09 / %x0b-0c / %x0e-3a / %x3c-ff)
                     target="RFC2818">HTTPS</xref>.
                   </t>
                   <t>
-                    The authority, which is the IdP domain name.  The authority
-                    MAY contain a non-default port number.  Any port number is
-                    removed when determining if an asserted identity matches the
-                    name of the IdP.  The authority MUST NOT include a userinfo
-                    sub-component.
+                    The <xref target="RFC3986">authority</xref>.  As noted above, 
+                    the authority MAY contain a  non-default port number or 
+                    userinfo sub-component.  Both are removed when determining 
+                    if an asserted identity matches the name of the IdP.  
                   </t>
                   <t>
                     The path, starting with "/.well-known/idp-proxy/" and


### PR DESCRIPTION
This references RFC 3986 authority instead of providing a definition for IdP domain.  This change means that userinfo sub-components are permitted, as are non-default ports, but also states that both are removed before matching against the certificate.