### PR TITLE
Adding MUX Category to IANA Considerations

### DIFF
--- a/draft-ietf-rtcweb-security-arch.xml
+++ b/draft-ietf-rtcweb-security-arch.xml
@@ -1944,7 +1944,8 @@ extension-att-value = 1*(%x01-09 / %x0b-0c / %x0e-3a / %x3c-ff)
             binding an identity to the transport-level security session.</t>
             <t hangText="Appropriate Values:">See <xref
             target="sec.a-identity"/> of RFCXXXX [[Editor Note: This
-            document.</t>
+            document.]]</t>
+            <t hangText="Mux Category:">NORMAL.</t>
           </list>
         </t>
       </section>


### PR DESCRIPTION
[draft-ietf-mmusic-sdp-mux-attributes](https://datatracker.ietf.org/doc/draft-ietf-mmusic-sdp-mux-attributes/) adds "MUX Category" to the required fields to register an SDP attribute.  